### PR TITLE
Allow FST builder to use different writer

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/fst/BytesStore.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/BytesStore.java
@@ -21,13 +21,12 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
-import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 
 // TODO: merge with PagedBytes, except PagedBytes doesn't
 // let you read while writing which FST needs
 
-class BytesStore extends FSTWriter implements Accountable {
+class BytesStore extends FSTWriter {
 
   private static final long BASE_RAM_BYTES_USED =
       RamUsageEstimator.shallowSizeOfInstance(BytesStore.class)
@@ -50,6 +49,7 @@ class BytesStore extends FSTWriter implements Accountable {
   }
 
   /** Absolute write byte; you must ensure dest is &lt; max position written so far. */
+  @Override
   public void writeByte(long dest, byte b) {
     int blockIndex = (int) (dest >> blockBits);
     byte[] block = blocks.get(blockIndex);
@@ -181,6 +181,7 @@ class BytesStore extends FSTWriter implements Accountable {
    * Absolute copy bytes self to self, without changing the position. Note: this cannot "grow" the
    * bytes, so must only call it on already written parts.
    */
+  @Override
   public void copyBytes(long src, long dest, int len) {
     // System.out.println("BS.copyBytes src=" + src + " dest=" + dest + " len=" + len);
     assert src < dest;
@@ -239,6 +240,7 @@ class BytesStore extends FSTWriter implements Accountable {
   }
 
   /** Copies bytes from this store to a target byte array. */
+  @Override
   public void copyBytes(long src, byte[] dest, int offset, int len) {
     int blockIndex = (int) (src >> blockBits);
     int upto = (int) (src & blockMask);
@@ -277,6 +279,7 @@ class BytesStore extends FSTWriter implements Accountable {
   }
 
   /** Reverse from srcPos, inclusive, to destPos, inclusive. */
+  @Override
   public void reverse(long srcPos, long destPos) {
     assert srcPos < destPos;
     assert destPos < getPosition();
@@ -315,6 +318,7 @@ class BytesStore extends FSTWriter implements Accountable {
     }
   }
 
+  @Override
   public void skipBytes(int len) {
     while (len > 0) {
       int chunk = blockSize - nextWrite;
@@ -330,6 +334,7 @@ class BytesStore extends FSTWriter implements Accountable {
     }
   }
 
+  @Override
   public long getPosition() {
     return ((long) blocks.size() - 1) * blockSize + nextWrite;
   }
@@ -338,6 +343,7 @@ class BytesStore extends FSTWriter implements Accountable {
    * Pos must be less than the max position written so far! Ie, you cannot "grow" the file with
    * this!
    */
+  @Override
   public void truncate(long newLen) {
     assert newLen <= getPosition();
     assert newLen >= 0;
@@ -367,6 +373,7 @@ class BytesStore extends FSTWriter implements Accountable {
   }
 
   /** Writes all of our bytes to the target {@link DataOutput}. */
+  @Override
   public void writeTo(DataOutput out) throws IOException {
     for (byte[] block : blocks) {
       out.writeBytes(block, 0, block.length);

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
@@ -862,7 +862,8 @@ public final class FST<T> implements Accountable {
       FSTCompiler<T> fstCompiler,
       FSTCompiler.UnCompiledNode<T> nodeIn,
       long startAddress,
-      int maxBytesPerArc) throws IOException {
+      int maxBytesPerArc)
+      throws IOException {
     // Build the header in a buffer.
     // It is a false/special arc which is in fact a node header with node flags followed by node
     // metadata.
@@ -913,7 +914,8 @@ public final class FST<T> implements Accountable {
       FSTCompiler.UnCompiledNode<T> nodeIn,
       long startAddress,
       int maxBytesPerArcWithoutLabel,
-      int labelRange) throws IOException {
+      int labelRange)
+      throws IOException {
     // Expand the arcs backwards in a buffer because we remove the labels.
     // So the obtained arcs might occupy less space. This is the reason why this
     // whole method is more complex.
@@ -989,7 +991,8 @@ public final class FST<T> implements Accountable {
       FSTCompiler<T> fstCompiler,
       FSTCompiler.UnCompiledNode<T> nodeIn,
       long dest,
-      int numPresenceBytes) throws IOException {
+      int numPresenceBytes)
+      throws IOException {
     long bytePos = dest;
     byte presenceBits = 1; // The first arc is always present.
     int presenceIndex = 0;

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -259,6 +259,7 @@ public class FSTCompiler<T> {
      *
      * @deprecated use {@link #fstWriter(FSTWriter)} instead
      */
+    @Deprecated
     public Builder<T> bytesPageBits(int bytesPageBits) {
       return fstWriter(new BytesStore(bytesPageBits));
     }

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -101,7 +101,17 @@ public class FSTCompiler<T> {
    * tuning and tweaking, see {@link Builder}.
    */
   public FSTCompiler(FST.INPUT_TYPE inputType, Outputs<T> outputs) {
-    this(inputType, 0, 0, true, true, Integer.MAX_VALUE, outputs, true, new BytesStore(DEFAULT_BLOCK_BITS), 1f);
+    this(
+        inputType,
+        0,
+        0,
+        true,
+        true,
+        Integer.MAX_VALUE,
+        outputs,
+        true,
+        new BytesStore(DEFAULT_BLOCK_BITS),
+        1f);
   }
 
   private FSTCompiler(
@@ -242,10 +252,11 @@ public class FSTCompiler<T> {
 
     /**
      * How many bits wide to make each byte[] block in the BytesStore; if you know the FST will be
-     * large then make this larger. For example 15 bits = 32768 byte pages.
-     * Note: Setting this will make the FST use BytesStore to write and override the settings in
-     * {@link #fstWriter}
+     * large then make this larger. For example 15 bits = 32768 byte pages. Note: Setting this will
+     * make the FST use BytesStore to write and override the settings in {@link #fstWriter}
+     *
      * <p>Default = 15.
+     *
      * @deprecated use {@link #fstWriter(FSTWriter)} instead
      */
     public Builder<T> bytesPageBits(int bytesPageBits) {
@@ -255,7 +266,8 @@ public class FSTCompiler<T> {
     /**
      * Set the {@link FSTWriter} which is used for low-level writing of FST.
      *
-     * Note: Setting this will override the settings in {@link #bytesPageBits(int)}
+     * <p>Note: Setting this will override the settings in {@link #bytesPageBits(int)}
+     *
      * @param fstWriter the FSTWriter
      * @return this builder
      */

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -94,7 +94,7 @@ public class FSTCompiler<T> {
   final float directAddressingMaxOversizingFactor;
   long directAddressingExpansionCredit;
 
-  final FSTWriter bytes;
+  final FSTWriter fstWriter;
 
   /**
    * Instantiates an FST/FSA builder with default settings and pruning options turned off. For more
@@ -132,10 +132,10 @@ public class FSTCompiler<T> {
     this.allowFixedLengthArcs = allowFixedLengthArcs;
     this.directAddressingMaxOversizingFactor = directAddressingMaxOversizingFactor;
     fst = new FST<>(inputType, outputs, fstWriter);
-    bytes = fstWriter;
-    assert bytes != null;
+    this.fstWriter = fstWriter;
+    assert this.fstWriter != null;
     if (doShareSuffix) {
-      dedupHash = new NodeHash<>(fst, bytes.getReverseReaderForSuffixSharing());
+      dedupHash = new NodeHash<>(fst, this.fstWriter.getReverseReaderForSuffixSharing());
     } else {
       dedupHash = null;
     }
@@ -335,7 +335,7 @@ public class FSTCompiler<T> {
 
   private CompiledNode compileNode(UnCompiledNode<T> nodeIn, int tailLength) throws IOException {
     final long node;
-    long bytesPosStart = bytes.getPosition();
+    long bytesPosStart = fstWriter.getPosition();
     if (dedupHash != null
         && (doShareNonSingletonNodes || nodeIn.numArcs <= 1)
         && tailLength <= shareMaxTailLength) {
@@ -350,7 +350,7 @@ public class FSTCompiler<T> {
     }
     assert node != -2;
 
-    long bytesPosEnd = bytes.getPosition();
+    long bytesPosEnd = fstWriter.getPosition();
     if (bytesPosEnd != bytesPosStart) {
       // The FST added a new node:
       assert bytesPosEnd > bytesPosStart;
@@ -496,7 +496,7 @@ public class FSTCompiler<T> {
     }
     */
 
-    bytes.beforeAdded(input);
+    fstWriter.beforeAdded(input);
 
     // De-dup NO_OUTPUT since it must be a singleton:
     if (output.equals(NO_OUTPUT)) {
@@ -517,7 +517,7 @@ public class FSTCompiler<T> {
       frontier[0].inputCount++;
       frontier[0].isFinal = true;
       fst.setEmptyOutput(output);
-      bytes.afterAdded(input);
+      fstWriter.afterAdded(input);
       return;
     }
 
@@ -602,7 +602,7 @@ public class FSTCompiler<T> {
     // save last input
     lastInput.copyInts(input);
 
-    bytes.afterAdded(input);
+    fstWriter.afterAdded(input);
 
     // System.out.println("  count[0]=" + frontier[0].inputCount);
   }

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTWriter.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util.fst;
+
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.IntsRef;
+
+import java.io.IOException;
+
+/**
+ * Abstract class which provides low-level functionality to write to a FST
+ */
+public abstract class FSTWriter extends DataOutput implements Accountable {
+
+    /**
+     * Truncate the FST data to a new length
+     * @param newLen the new length of the FST data
+     * @throws IOException
+     */
+    public abstract void truncate(long newLen) throws IOException;
+
+    /**
+     * Reverse the data from srcPos to destPos, inclusively
+     * @param srcPos the src position
+     * @param destPos the dest position
+     * @throws IOException
+     */
+    public abstract void reverse(long srcPos, long destPos) throws IOException;
+
+    /**
+     * Skip a number of bytes from the current position
+     * @param len the bytes to skip
+     * @throws IOException
+     */
+    public abstract void skipBytes(int len) throws IOException;
+
+    /**
+     * Copy <code>len</code> bytes from <code>src</code> to <code>dest</code>.
+     * This can only be called on parts already written.
+     *
+     * @param src the position to copy from
+     * @param dest the position to copy to
+     * @param len the number of bytes to copy
+     * @throws IOException
+     */
+    public abstract void copyBytes(long src, long dest, int len) throws IOException;
+
+    /**
+     * Copy <code>len</code> bytes from <code>src</code> position to <code>dest</code> buffer.
+     *
+     * @param src the position to copy from
+     * @param dest the buffer to copy to
+     * @param offset the offset of the buffer to copy to
+     * @param len the number of bytes to copy
+     * @throws IOException
+     */
+    public abstract void copyBytes(long src, byte[] dest, int offset, int len) throws IOException;
+
+    /**
+     * Write <code>len</code> bytes to <code>dest</code> position
+     * @param dest the position to write to
+     * @param b the data to write
+     * @param offset the offset of the byte array to write
+     * @param len the number of bytes to write
+     * @throws IOException
+     */
+    public abstract void writeBytes(long dest, byte[] b, int offset, int len) throws IOException;
+
+    /**
+     * Write a single byte at the specified position
+     * @param dest the position to write to
+     * @param b the byte to write
+     * @throws IOException
+     */
+    public abstract void writeByte(long dest, byte b) throws IOException;
+
+    /**
+     * Get the current position (or pointer) of the writer
+     * @return the current position of the writer
+     */
+    public abstract long getPosition();
+
+    /**
+     * Called when the FST construction is finished and no more node can be added to it.
+     * Freezing, optimizing the datastructure can be done here
+     * @throws IOException
+     */
+    public void finish() throws IOException {
+        // do nothing by default
+    }
+
+    /**
+     * Called before adding an input
+     * @param input the input to be added
+     * @throws IOException
+     */
+    public void beforeAdded(IntsRef input) throws IOException {
+        // do nothing by default
+    }
+
+    /**
+     * Called after an input is added to the FST
+     * Flushing, cleaning up, etc. can be done here
+     * @param input the added input
+     * @throws IOException
+     */
+    public void afterAdded(IntsRef input) throws IOException {
+        // do nothing by default
+    }
+
+    /**
+     * Get the BytesReader of the FST
+     * @return the BytesReader
+     */
+    public abstract FST.BytesReader getReverseReader();
+
+    /**
+     * Get the BytesReader of the FST used for suffix sharing
+     * @return the BytesReader
+     */
+    public abstract FST.BytesReader getReverseReaderForSuffixSharing();
+
+    /**
+     * Write this FST data to a DataOutput. Must be called after {@link #finish()}
+     * @param out the DataOutput
+     * @throws IOException
+     */
+    public abstract void writeTo(DataOutput out) throws IOException;
+}

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTWriter.java
@@ -16,129 +16,137 @@
  */
 package org.apache.lucene.util.fst;
 
+import java.io.IOException;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.IntsRef;
 
-import java.io.IOException;
-
-/**
- * Abstract class which provides low-level functionality to write to a FST
- */
+/** Abstract class which provides low-level functionality to write to a FST */
 public abstract class FSTWriter extends DataOutput implements Accountable {
 
-    /**
-     * Truncate the FST data to a new length
-     * @param newLen the new length of the FST data
-     * @throws IOException
-     */
-    public abstract void truncate(long newLen) throws IOException;
+  /**
+   * Truncate the FST data to a new length
+   *
+   * @param newLen the new length of the FST data
+   * @throws IOException
+   */
+  public abstract void truncate(long newLen) throws IOException;
 
-    /**
-     * Reverse the data from srcPos to destPos, inclusively
-     * @param srcPos the src position
-     * @param destPos the dest position
-     * @throws IOException
-     */
-    public abstract void reverse(long srcPos, long destPos) throws IOException;
+  /**
+   * Reverse the data from srcPos to destPos, inclusively
+   *
+   * @param srcPos the src position
+   * @param destPos the dest position
+   * @throws IOException
+   */
+  public abstract void reverse(long srcPos, long destPos) throws IOException;
 
-    /**
-     * Skip a number of bytes from the current position
-     * @param len the bytes to skip
-     * @throws IOException
-     */
-    public abstract void skipBytes(int len) throws IOException;
+  /**
+   * Skip a number of bytes from the current position
+   *
+   * @param len the bytes to skip
+   * @throws IOException
+   */
+  public abstract void skipBytes(int len) throws IOException;
 
-    /**
-     * Copy <code>len</code> bytes from <code>src</code> to <code>dest</code>.
-     * This can only be called on parts already written.
-     *
-     * @param src the position to copy from
-     * @param dest the position to copy to
-     * @param len the number of bytes to copy
-     * @throws IOException
-     */
-    public abstract void copyBytes(long src, long dest, int len) throws IOException;
+  /**
+   * Copy <code>len</code> bytes from <code>src</code> to <code>dest</code>. This can only be called
+   * on parts already written.
+   *
+   * @param src the position to copy from
+   * @param dest the position to copy to
+   * @param len the number of bytes to copy
+   * @throws IOException
+   */
+  public abstract void copyBytes(long src, long dest, int len) throws IOException;
 
-    /**
-     * Copy <code>len</code> bytes from <code>src</code> position to <code>dest</code> buffer.
-     *
-     * @param src the position to copy from
-     * @param dest the buffer to copy to
-     * @param offset the offset of the buffer to copy to
-     * @param len the number of bytes to copy
-     * @throws IOException
-     */
-    public abstract void copyBytes(long src, byte[] dest, int offset, int len) throws IOException;
+  /**
+   * Copy <code>len</code> bytes from <code>src</code> position to <code>dest</code> buffer.
+   *
+   * @param src the position to copy from
+   * @param dest the buffer to copy to
+   * @param offset the offset of the buffer to copy to
+   * @param len the number of bytes to copy
+   * @throws IOException
+   */
+  public abstract void copyBytes(long src, byte[] dest, int offset, int len) throws IOException;
 
-    /**
-     * Write <code>len</code> bytes to <code>dest</code> position
-     * @param dest the position to write to
-     * @param b the data to write
-     * @param offset the offset of the byte array to write
-     * @param len the number of bytes to write
-     * @throws IOException
-     */
-    public abstract void writeBytes(long dest, byte[] b, int offset, int len) throws IOException;
+  /**
+   * Write <code>len</code> bytes to <code>dest</code> position
+   *
+   * @param dest the position to write to
+   * @param b the data to write
+   * @param offset the offset of the byte array to write
+   * @param len the number of bytes to write
+   * @throws IOException
+   */
+  public abstract void writeBytes(long dest, byte[] b, int offset, int len) throws IOException;
 
-    /**
-     * Write a single byte at the specified position
-     * @param dest the position to write to
-     * @param b the byte to write
-     * @throws IOException
-     */
-    public abstract void writeByte(long dest, byte b) throws IOException;
+  /**
+   * Write a single byte at the specified position
+   *
+   * @param dest the position to write to
+   * @param b the byte to write
+   * @throws IOException
+   */
+  public abstract void writeByte(long dest, byte b) throws IOException;
 
-    /**
-     * Get the current position (or pointer) of the writer
-     * @return the current position of the writer
-     */
-    public abstract long getPosition();
+  /**
+   * Get the current position (or pointer) of the writer
+   *
+   * @return the current position of the writer
+   */
+  public abstract long getPosition();
 
-    /**
-     * Called when the FST construction is finished and no more node can be added to it.
-     * Freezing, optimizing the datastructure can be done here
-     * @throws IOException
-     */
-    public void finish() throws IOException {
-        // do nothing by default
-    }
+  /**
+   * Called when the FST construction is finished and no more node can be added to it. Freezing,
+   * optimizing the datastructure can be done here
+   *
+   * @throws IOException
+   */
+  public void finish() throws IOException {
+    // do nothing by default
+  }
 
-    /**
-     * Called before adding an input
-     * @param input the input to be added
-     * @throws IOException
-     */
-    public void beforeAdded(IntsRef input) throws IOException {
-        // do nothing by default
-    }
+  /**
+   * Called before adding an input
+   *
+   * @param input the input to be added
+   * @throws IOException
+   */
+  public void beforeAdded(IntsRef input) throws IOException {
+    // do nothing by default
+  }
 
-    /**
-     * Called after an input is added to the FST
-     * Flushing, cleaning up, etc. can be done here
-     * @param input the added input
-     * @throws IOException
-     */
-    public void afterAdded(IntsRef input) throws IOException {
-        // do nothing by default
-    }
+  /**
+   * Called after an input is added to the FST Flushing, cleaning up, etc. can be done here
+   *
+   * @param input the added input
+   * @throws IOException
+   */
+  public void afterAdded(IntsRef input) throws IOException {
+    // do nothing by default
+  }
 
-    /**
-     * Get the BytesReader of the FST
-     * @return the BytesReader
-     */
-    public abstract FST.BytesReader getReverseReader();
+  /**
+   * Get the BytesReader of the FST
+   *
+   * @return the BytesReader
+   */
+  public abstract FST.BytesReader getReverseReader();
 
-    /**
-     * Get the BytesReader of the FST used for suffix sharing
-     * @return the BytesReader
-     */
-    public abstract FST.BytesReader getReverseReaderForSuffixSharing();
+  /**
+   * Get the BytesReader of the FST used for suffix sharing
+   *
+   * @return the BytesReader
+   */
+  public abstract FST.BytesReader getReverseReaderForSuffixSharing();
 
-    /**
-     * Write this FST data to a DataOutput. Must be called after {@link #finish()}
-     * @param out the DataOutput
-     * @throws IOException
-     */
-    public abstract void writeTo(DataOutput out) throws IOException;
+  /**
+   * Write this FST data to a DataOutput. Must be called after {@link #finish()}
+   *
+   * @param out the DataOutput
+   * @throws IOException
+   */
+  public abstract void writeTo(DataOutput out) throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTWriter.java
@@ -28,7 +28,6 @@ public abstract class FSTWriter extends DataOutput implements Accountable {
    * Truncate the FST data to a new length
    *
    * @param newLen the new length of the FST data
-   * @throws IOException
    */
   public abstract void truncate(long newLen) throws IOException;
 
@@ -37,7 +36,7 @@ public abstract class FSTWriter extends DataOutput implements Accountable {
    *
    * @param srcPos the src position
    * @param destPos the dest position
-   * @throws IOException
+   * @throws IOException if exception occurred during the operation
    */
   public abstract void reverse(long srcPos, long destPos) throws IOException;
 
@@ -45,7 +44,7 @@ public abstract class FSTWriter extends DataOutput implements Accountable {
    * Skip a number of bytes from the current position
    *
    * @param len the bytes to skip
-   * @throws IOException
+   * @throws IOException if exception occurred during the operation
    */
   public abstract void skipBytes(int len) throws IOException;
 
@@ -56,7 +55,7 @@ public abstract class FSTWriter extends DataOutput implements Accountable {
    * @param src the position to copy from
    * @param dest the position to copy to
    * @param len the number of bytes to copy
-   * @throws IOException
+   * @throws IOException if exception occurred during the operation
    */
   public abstract void copyBytes(long src, long dest, int len) throws IOException;
 
@@ -67,7 +66,7 @@ public abstract class FSTWriter extends DataOutput implements Accountable {
    * @param dest the buffer to copy to
    * @param offset the offset of the buffer to copy to
    * @param len the number of bytes to copy
-   * @throws IOException
+   * @throws IOException if exception occurred during the operation
    */
   public abstract void copyBytes(long src, byte[] dest, int offset, int len) throws IOException;
 
@@ -78,7 +77,7 @@ public abstract class FSTWriter extends DataOutput implements Accountable {
    * @param b the data to write
    * @param offset the offset of the byte array to write
    * @param len the number of bytes to write
-   * @throws IOException
+   * @throws IOException if exception occurred during the operation
    */
   public abstract void writeBytes(long dest, byte[] b, int offset, int len) throws IOException;
 
@@ -87,7 +86,7 @@ public abstract class FSTWriter extends DataOutput implements Accountable {
    *
    * @param dest the position to write to
    * @param b the byte to write
-   * @throws IOException
+   * @throws IOException if exception occurred during the operation
    */
   public abstract void writeByte(long dest, byte b) throws IOException;
 
@@ -102,7 +101,7 @@ public abstract class FSTWriter extends DataOutput implements Accountable {
    * Called when the FST construction is finished and no more node can be added to it. Freezing,
    * optimizing the datastructure can be done here
    *
-   * @throws IOException
+   * @throws IOException if exception occurred during the operation
    */
   public void finish() throws IOException {
     // do nothing by default
@@ -112,7 +111,7 @@ public abstract class FSTWriter extends DataOutput implements Accountable {
    * Called before adding an input
    *
    * @param input the input to be added
-   * @throws IOException
+   * @throws IOException if exception occurred during the operation
    */
   public void beforeAdded(IntsRef input) throws IOException {
     // do nothing by default
@@ -122,7 +121,7 @@ public abstract class FSTWriter extends DataOutput implements Accountable {
    * Called after an input is added to the FST Flushing, cleaning up, etc. can be done here
    *
    * @param input the added input
-   * @throws IOException
+   * @throws IOException if exception occurred during the operation
    */
   public void afterAdded(IntsRef input) throws IOException {
     // do nothing by default
@@ -146,7 +145,7 @@ public abstract class FSTWriter extends DataOutput implements Accountable {
    * Write this FST data to a DataOutput. Must be called after {@link #finish()}
    *
    * @param out the DataOutput
-   * @throws IOException
+   * @throws IOException if exception occurred during the operation
    */
   public abstract void writeTo(DataOutput out) throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/util/fst/SingleBlockBytesStore.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/SingleBlockBytesStore.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util.fst;
+
+import org.apache.lucene.store.ByteArrayDataOutput;
+
+import java.io.IOException;
+
+/**
+ * Implementation of {@link FSTWriter} which use similar behavior as {@link BytesStore}, but upon calling
+ * {@link #finish()}, if the size is not too large, it will merge all blocks into a single byte array.
+ *
+ * For reading with the {@link #getReverseReader()}, it will be more efficient than {@link BytesStore} as it has less overhead.
+ * However, during the call to {@link #finish()} it will temporarily need ~2x more heap than {@link BytesStore}, thus it is
+ * recommended for small (less than 1GB), write-once-read-many FST.
+ */
+public class SingleBlockBytesStore extends BytesStore {
+
+    final int maxBits;
+
+    byte[] bytes;
+
+    /**
+     * constructor
+     * @param blockBits the size of each byte block used during constructing the FST
+     * @param maxBits the maximum size of the byte array to hold the final FST. if the FST is larger than this threshold,
+     *                it will use the BytesStore's byte blocks instead
+     */
+    public SingleBlockBytesStore(int blockBits, int maxBits) {
+        super(blockBits);
+        if (maxBits < 1 || maxBits > 30) {
+            throw new IllegalArgumentException("maxBits should be 1 .. 30; got " + maxBits);
+        }
+
+        this.maxBits = maxBits;
+    }
+
+    @Override
+    public void finish() throws IOException {
+        super.finish();
+
+        long pos = super.getPosition();
+
+        if (pos > 1 << this.maxBits) {
+            // the buffer is too large, keep with the BytesStore implementation
+            return;
+        }
+
+        // merge all blocks into a single byte array
+        bytes = new byte[(int) pos];
+        writeTo(new ByteArrayDataOutput(bytes));
+
+        blocks.clear();
+        blocks.add(bytes);
+    }
+
+    @Override
+    public long getPosition() {
+        if (bytes == null) { // before calling finish()
+            return super.getPosition();
+        }
+        return bytes.length;
+    }
+}


### PR DESCRIPTION
### Description

Refactor the method in `BytesStore` needed for FST construction to an abstract class and allow it to be passed from `FSTCompiler.Builder`. The Builder will still maintain `bytesPageBits(int)` for backward-compatibility, in which it will pass the BytesStore.